### PR TITLE
Add missing container type option

### DIFF
--- a/dist/pagination.d.ts
+++ b/dist/pagination.d.ts
@@ -1,6 +1,6 @@
 declare namespace Pagination {
     interface Options {
-        container: HTMLDivElement;
+        container: HTMLDivElement | JQuery;
         callPageClickCallbackOnInit?: boolean;
         pageClickCallback?: (pageNumber: number) => void;
         pageClickUrl?: string | ((pageNumber: number) => string);

--- a/src/pagination.options.ts
+++ b/src/pagination.options.ts
@@ -1,6 +1,6 @@
 declare namespace Pagination {
     interface Options {
-        container: HTMLDivElement;
+        container: HTMLDivElement | JQuery;
         callPageClickCallbackOnInit?: boolean;
         pageClickCallback?: (pageNumber: number) => void;
         pageClickUrl?: string | ((pageNumber: number) => string);


### PR DESCRIPTION
From README.md:
> - container - The place in the DOM, where to render this component. The parameter type is HTMLDivElement or **JQuery**. This parameter is required.

Type JQuery was missing in the type definitions, so only HTMLDivElement was allowed.